### PR TITLE
Use author name and email

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pretestedintegration/scm/git/SquashCommitStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/pretestedintegration/scm/git/SquashCommitStrategy.java
@@ -79,10 +79,12 @@ public class SquashCommitStrategy extends IntegrationStrategy {
         }
         
         try {
-            
+            exitCode = gitbridge.git(build, launcher, listener, out, "log", "-1", "--pretty=format:\"%an <%ae>\"", gitDataBranch.getName());
+            String authorInfo = out.toString();
+            out.reset();
             exitCode = gitbridge.git(build, launcher, listener, out, "merge", "--squash", gitDataBranch.getName());
-            exitCodeCommit = gitbridge.git(build, launcher, listener, out, "commit", "-m", String.format("Integrated %s", gitDataBranch.getName()));
-        
+            exitCodeCommit = gitbridge.git(build, launcher, listener, out, "commit", "-m", String.format("Integrated %s", gitDataBranch.getName()), String.format("--author=%s", authorInfo));
+
         } catch (Exception ex) { /*Handled below */ }
         
         if (exitCode != 0) {


### PR DESCRIPTION
When squashing commit(s) use the name and email information of the
author from the commit at the tip of the branch to be squashed.
Still use the system configuration for the comitter information.

Signed-off-by: Aske Olsson askeolsson@gmail.com
