### PR TITLE
Remove obsolete git checkout args

### DIFF
--- a/docs/scripted-pipelines.md
+++ b/docs/scripted-pipelines.md
@@ -21,7 +21,7 @@ This is an example of a pipeline script with a single pipeline job that does Pre
 
 ``` groovy
 node {
-   checkout([$class: 'GitSCM', branches: [[name: '*/ready/**']], doGenerateSubmoduleConfigurations: false, extensions: [pretestedIntegration(pretestedIntegration: squash(), integrationBranch: 'master', repoName: 'origin')], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'GitHub', url: 'https://github.com/Praqma/phlow-test.git']]])
+   checkout([$class: 'GitSCM', branches: [[name: '*/ready/**']], extensions: [pretestedIntegration(pretestedIntegration: squash(), integrationBranch: 'master', repoName: 'origin')], userRemoteConfigs: [[credentialsId: 'GitHub', url: 'https://github.com/Praqma/phlow-test.git']]])
    sh 'mvn install'
    pretestedIntegrationPublisher()
 }

--- a/src/test/java/org/jenkinsci/plugins/pretestedintegration/integration/scm/git/AccumulatedCommitStrategyIT.java
+++ b/src/test/java/org/jenkinsci/plugins/pretestedintegration/integration/scm/git/AccumulatedCommitStrategyIT.java
@@ -257,7 +257,7 @@ public class AccumulatedCommitStrategyIT {
                 "    stages {\n" +
                 "        stage(\"checkout\") {\n" +
                 "            steps {\n" +
-                "                checkout([$class: 'GitSCM', branches: [[name: '*/ready/**']], doGenerateSubmoduleConfigurations: false, extensions: [pretestedIntegration(gitIntegrationStrategy: accumulated(), integrationBranch: 'master', repoName: 'origin')], submoduleCfg: [], userRemoteConfigs: [[url: '%URL']]])\n" +
+                "                checkout([$class: 'GitSCM', branches: [[name: '*/ready/**']], extensions: [pretestedIntegration(gitIntegrationStrategy: accumulated(), integrationBranch: 'master', repoName: 'origin')], userRemoteConfigs: [[url: '%URL']]])\n" +
                 "            }\n" +
                 "        }\n" +
                 "        stage(\"publish\") {\n" +

--- a/src/test/java/org/jenkinsci/plugins/pretestedintegration/integration/scm/git/GHI98_SupportForCredentialsIT.java
+++ b/src/test/java/org/jenkinsci/plugins/pretestedintegration/integration/scm/git/GHI98_SupportForCredentialsIT.java
@@ -43,7 +43,7 @@ public class GHI98_SupportForCredentialsIT {
     final String uName = System.getProperty("usernameForTest");
     final String repo = System.getProperty("repoForTest");
     final String pipelineScript = "node {\n" +
-        "    checkout([$class: 'GitSCM', branches: [[name: '*/ready/**']], doGenerateSubmoduleConfigurations: false, extensions: [pretestedIntegration(gitIntegrationStrategy: squash(), integrationBranch: 'master', repoName: 'origin')], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'pipCredentials', url: '%repoForTest']]])\n" +
+        "    checkout([$class: 'GitSCM', branches: [[name: '*/ready/**']], extensions: [pretestedIntegration(gitIntegrationStrategy: squash(), integrationBranch: 'master', repoName: 'origin')], userRemoteConfigs: [[credentialsId: 'pipCredentials', url: '%repoForTest']]])\n" +
         "    pretestedIntegrationPublisher()\n" +
         "    echo \"Ohoy we've got success!\"\n" +
         "}";

--- a/src/test/java/org/jenkinsci/plugins/pretestedintegration/integration/scm/git/PipAsGitExtensionIT.java
+++ b/src/test/java/org/jenkinsci/plugins/pretestedintegration/integration/scm/git/PipAsGitExtensionIT.java
@@ -106,9 +106,7 @@ public class PipAsGitExtensionIT {
                 "node {",
                 "checkout([$class: 'GitSCM'," +
                         " branches: [[name: '*/ready/**']]," +
-                        " doGenerateSubmoduleConfigurations: false," +
                         " extensions: [pretestedIntegration(gitIntegrationStrategy: squash(), integrationBranch: 'master', repoName: 'origin')]," +
-                        " submoduleCfg: []," +
                         " userRemoteConfigs: [[url: '" + "file://" + repo.getDirectory().getAbsolutePath() + "']]])",
                 "pretestedIntegrationPublisher()",
                 "}"), "\n"), false);

--- a/src/test/java/org/jenkinsci/plugins/pretestedintegration/integration/scm/git/SquashCommitStrategyIT.java
+++ b/src/test/java/org/jenkinsci/plugins/pretestedintegration/integration/scm/git/SquashCommitStrategyIT.java
@@ -60,7 +60,7 @@ public class SquashCommitStrategyIT {
                 "    stages {\n" +
                 "        stage(\"checkout\") {\n" +
                 "            steps {\n" +
-                "                checkout([$class: 'GitSCM', branches: [[name: '*/ready/**']], doGenerateSubmoduleConfigurations: false, extensions: [pretestedIntegration(gitIntegrationStrategy: squash(), integrationBranch: 'master', repoName: 'origin')], submoduleCfg: [], userRemoteConfigs: [[url: '%URL']]])\n" +
+                "                checkout([$class: 'GitSCM', branches: [[name: '*/ready/**']], extensions: [pretestedIntegration(gitIntegrationStrategy: squash(), integrationBranch: 'master', repoName: 'origin')], userRemoteConfigs: [[url: '%URL']]])\n" +
                 "            }\n" +
                 "        }\n" +
                 "        stage(\"publish\") {\n" +


### PR DESCRIPTION
Git plugin 4.6.0 removes the outdated default arguments.  Their default values were used in the tests previously.  No reason to show the default values to users in tests or in example scripts.